### PR TITLE
Template strings

### DIFF
--- a/BusinessLogic/Entities/Event.cs
+++ b/BusinessLogic/Entities/Event.cs
@@ -1,5 +1,6 @@
 using Newtonsoft.Json.Linq;
 using System;
+using System.Collections.Generic;
 
 namespace EventManager.BusinessLogic.Entities
 {
@@ -9,6 +10,6 @@ namespace EventManager.BusinessLogic.Entities
         public string Payload { get; set; }
         public DateTime Timestamp { get; set; }
         public JObject ExtraParams { get; set; }
-
+        public Dictionary<string, string> UrlTemplateValues { get; set; }
     }
 }

--- a/BusinessLogic/Entities/EventDispatcher.cs
+++ b/BusinessLogic/Entities/EventDispatcher.cs
@@ -112,18 +112,42 @@ namespace EventManager.BusinessLogic.Entities
         }
 
         /// <summary>
+        /// This is a simplified version of the <see cref="EventDispatcher.Dispatch(Event)"/> method. But instead
+        /// of accepting a complete <see cref="Event"/>, it takes the event name, payload, and the template values for the URL,
+        /// and proceeds to build an event out of these.
+        /// 
+        /// The event dispatched with this method will have a `Timestamp` of `DateTime.UtcNow`, and the `ExtraParams`
+        /// will be `null. If you need to specify any of these then use the normal `Dispatch` method.
+        /// </summary>
+        /// <param name="eventName"></param>
+        /// <param name="eventPayload"></param>
+        /// <param name="urlTemplateValues"></param>
+        public void SimpleDispatch(string eventName, string eventPayload, Dictionary<string, string> urlTemplateValues)
+        {
+            this.Dispatch(new Event
+            {
+                Name = eventName,
+                Payload = eventPayload,
+                Timestamp = DateTime.UtcNow,
+                ExtraParams = null,
+                UrlTemplateValues = urlTemplateValues
+            });
+        }
+
+        /// <summary>
         /// Fire an Event to be listened by a Subscription
         /// </summary>
         /// <param name="e">Event object</param>
         public void Dispatch(Event e)
         {
-            Log.Debug("EventDispatcher.Dispatch");
+            Log.Debug($"EventDispatcher.Dispatch: Dispatching event with name '{e.Name}'");
             List<Subscription> subscriptions;
             if (eventSubscriptions.TryGetValue(e.Name, out subscriptions))
             {
-                Log.Debug("EventDispatcher.Dispatch: Found value");
+                Log.Debug($"EventDispatcher.Dispatch: Found subscriptions to event '{e.Name}', enqueuing items");
                 foreach (Subscription subscription in subscriptions)
                 {
+                    Log.Debug($"EventDispatcher.Dispatch: Enqueuing item for subscriber '{subscription.Subscriber.Name}', for event '{e.Name}'");
                     QueueItem queueItem = new QueueItem()
                     {
                         Guid = Guid.NewGuid(),
@@ -137,7 +161,7 @@ namespace EventManager.BusinessLogic.Entities
             }
             else
             {
-                Log.Debug("EventDispatcher.Dispatch: Value not found");
+                Log.Debug($"EventDispatcher.Dispatch: Nothing will be dispatched - No subscriptions found for event '{e.Name}'");
             }
         }
     }

--- a/BusinessLogic/Entities/EventDispatcher.cs
+++ b/BusinessLogic/Entities/EventDispatcher.cs
@@ -95,34 +95,15 @@ namespace EventManager.BusinessLogic.Entities
         /// of accepting a complete <see cref="Event"/>, it takes the event name and payload and proceeds to build
         /// an event out of these.
         /// 
-        /// The event dispatched with this method will have a `Timestamp` of `DateTime.UtcNow`, and the `ExtraParams`
-        /// will be `null. If you need to specify any of these then use the normal `Dispatch` method.
-        /// </summary>
-        /// <param name="eventName"></param>
-        /// <param name="eventPayload"></param>
-        public void SimpleDispatch(string eventName, string eventPayload)
-        {
-            this.Dispatch(new Event
-            {
-                Name = eventName,
-                Payload = eventPayload,
-                Timestamp = DateTime.UtcNow,
-                ExtraParams = null
-            });
-        }
-
-        /// <summary>
-        /// This is a simplified version of the <see cref="EventDispatcher.Dispatch(Event)"/> method. But instead
-        /// of accepting a complete <see cref="Event"/>, it takes the event name, payload, and the template values for the URL,
-        /// and proceeds to build an event out of these.
+        /// Optionally, also a dictionary of urlTemplateValues that will be used to replace the templateKeys in the
+        /// endpoint. By default this dictionary is null.
         /// 
         /// The event dispatched with this method will have a `Timestamp` of `DateTime.UtcNow`, and the `ExtraParams`
         /// will be `null. If you need to specify any of these then use the normal `Dispatch` method.
         /// </summary>
         /// <param name="eventName"></param>
         /// <param name="eventPayload"></param>
-        /// <param name="urlTemplateValues"></param>
-        public void SimpleDispatch(string eventName, string eventPayload, Dictionary<string, string> urlTemplateValues)
+        public void SimpleDispatch(string eventName, string eventPayload, Dictionary<string, string> urlTemplateValues = null)
         {
             this.Dispatch(new Event
             {

--- a/BusinessLogic/Entities/Queue.cs
+++ b/BusinessLogic/Entities/Queue.cs
@@ -130,7 +130,9 @@ namespace EventManager.BusinessLogic.Entities
                     else
                     {
                         // If the SendEvent fails (not OK) then sent back to the queue for it to be processed again
-                        Log.Debug("Queue.ProcessItem, Item Processed FAILED, back to queue " + item.Guid.ToString());
+                        Log.Error($"Queue.ProcessItem, Sending Item back to queue - Item ID: '{item.Guid.ToString()}' - " +
+                                  $"Process FAILED with code '{httpResponseMessage.StatusCode}' " +
+                                  $"and the following message: {httpResponseMessage.Content.ReadAsStringAsync().Result}");
                         Items.Enqueue(item);
 
                         if (Interlocked.Equals(running, 0)) //!running

--- a/BusinessLogic/Entities/Subscription.cs
+++ b/BusinessLogic/Entities/Subscription.cs
@@ -28,7 +28,7 @@ namespace EventManager.BusinessLogic.Entities
 
         /// <summary>
         /// This method can be used to replace the templateValues in the provided "str". Each template value in str 
-        /// should have the shape "{{templateValueName}}". This method will find all instances of said templateValues
+        /// should have the shape "{templateValueName}". This method will find all instances of said templateValues
         /// and look for "templateValueName" in the <paramref name="templateValues"/> dictionary. Note that if no templateValue
         /// is found for a key then this is an error and it will throw a <see cref="System.Collections.Generic.KeyNotFoundException"/>.
         /// </summary>
@@ -39,7 +39,7 @@ namespace EventManager.BusinessLogic.Entities
         {
             Log.Debug("Subscription.ApplyTemplateValuesToUri: applying string template replacement to endpoint");
 
-            var rx = new Regex(@"\{\{.*?\}\}",
+            var rx = new Regex(@"\{.*?\}",
                     RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
             var matches = rx.Matches(str);
@@ -48,7 +48,7 @@ namespace EventManager.BusinessLogic.Entities
                 Log.Debug($"Subscription.ApplyTemplateValuesToUri: replacing match for {m.Value}");
 
                 var val = m.Value;
-                var key = val.Replace("{{", "").Replace("}}", "");
+                var key = val.Replace("{", "").Replace("}", "");
 
                 // key should exist, otherwise this is an error
                 str = str.Replace(

--- a/BusinessLogic/Entities/Subscription.cs
+++ b/BusinessLogic/Entities/Subscription.cs
@@ -26,25 +26,23 @@ namespace EventManager.BusinessLogic.Entities
         {
         }
 
-        private Subscription Clone()
-        {
-            return (Subscription)this.MemberwiseClone();
-        }
-
         /// <summary>
-        /// 
+        /// This method can be used to replace the templateValues in the provided "str". Each template value in str 
+        /// should have the shape "{{templateValueName}}". This method will find all instances of said templateValues
+        /// and look for "templateValueName" in the <paramref name="templateValues"/> dictionary. Note that if no templateValue
+        /// is found for a key then this is an error and it will throw a <see cref="System.Collections.Generic.KeyNotFoundException"/>.
         /// </summary>
-        /// <param name="endpoint"></param>
+        /// <param name="str"></param>
         /// <param name="templateValues"></param>
-        /// <returns></returns>
-        private string ApplyTemplateValuesToUri(string endpoint, Dictionary<string, string> templateValues)
+        /// <returns>A new string with all the template values replaced</returns>
+        private string ApplyTemplateValuesToString(string str, Dictionary<string, string> templateValues)
         {
             Log.Debug("Subscription.ApplyTemplateValuesToUri: applying string template replacement to endpoint");
 
             var rx = new Regex(@"\{\{.*?\}\}",
                     RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-            var matches = rx.Matches(endpoint);
+            var matches = rx.Matches(str);
             foreach (Match m in matches)
             {
                 Log.Debug($"Subscription.ApplyTemplateValuesToUri: replacing match for {m.Value}");
@@ -53,13 +51,13 @@ namespace EventManager.BusinessLogic.Entities
                 var key = val.Replace("{{", "").Replace("}}", "");
 
                 // key should exist, otherwise this is an error
-                endpoint = endpoint.Replace(
+                str = str.Replace(
                     m.Value,
                     HttpUtility.UrlEncode(templateValues[key])
                 );
             }
 
-            return endpoint;
+            return str;
         }
 
         /// <summary>
@@ -84,9 +82,9 @@ namespace EventManager.BusinessLogic.Entities
                 {
                     // set specificSubscription to be a clone of `this` so that we don't affect `this`'s
                     // values
-                    specificSubscription = this.Clone();
+                    specificSubscription = (Subscription)this.MemberwiseClone();
 
-                    specificSubscription.EndPoint = this.ApplyTemplateValuesToUri(
+                    specificSubscription.EndPoint = this.ApplyTemplateValuesToString(
                         specificSubscription.EndPoint,
                         _event.UrlTemplateValues
                     );

--- a/EventManager.csproj
+++ b/EventManager.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;</TargetFrameworks>
     <RootNamespace>EventManager</RootNamespace>
     <PackageId>Cecropia.Utilities.EventManager</PackageId>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <Authors>Cecropia</Authors>
     <Company>Cecropia</Company>
     <!-- <GeneratePackageOnBuild>true</GeneratePackageOnBuild> -->


### PR DESCRIPTION
This PR introduces the functionality that allows users to specify "templateValues" in the endpoints for the subscriptions. When dispatching an event, the user will be able to also attach a dictionary of values that should be used to replace the template values. 

For example, consider we have the following subscription:

```json
      "Subscriptions":[
         {
            "EventName":"my_custom_event_name",
            "Subscribers":[
               {
                  "Name":"httpbin",
                  "Method":"POST",
                  "Endpoint":"/post/{{something}}/{{somethingelse}}"
               }
            ]
         }
      ]
```

Then when dispatching an event, the user can do the following:

```csharp
EventDispatcher.Instance.SimpleDispatch(
    "my_custom_event_name",
    payload,
    new Dictionary<string, string> {
        {"something", "hi"},
        {"somethingelse", "a-hardcoded-value"}
    }
);
```

The URL to which this event will be dispatched will be:

```
{{subscriberBaseURL}}/post/hi/a-hardcoded-value
```

When replacing the variables with the provided values from the dictionary, the values are URL Encoded, but it responsibility of the user ensuring that the values have the proper shape (eg, use `-` instead of spaces). 

Closes #24 

## Other things introduced in this PR

- A new "Dispatcher.SimpleDispatch" overload which also accepts a dictionary of templateValues
- Clean up some log expressions
- Subscription object can now do a shallow clone of iteself
