### PR TITLE
EM-27 Allow Synchronous events

### DIFF
--- a/BusinessLogic/Entities/Configuration/EventSubscriberConfiguration.cs
+++ b/BusinessLogic/Entities/Configuration/EventSubscriberConfiguration.cs
@@ -10,5 +10,6 @@ namespace EventManager.BusinessLogic.Entities.Configuration
         public string Name { get; set; } 
         public string Method { get; set; } = "POST";
         public string Endpoint { get; set; } = null;
+        public bool Synchronous { get; set; } = false;
     }
 }

--- a/BusinessLogic/Entities/Subscriber.cs
+++ b/BusinessLogic/Entities/Subscriber.cs
@@ -4,6 +4,10 @@ namespace EventManager.BusinessLogic.Entities
 {
     public class Subscriber
     {
+        public Subscriber(string name)
+        {
+            Name = name;
+        }
         public string Name { get; set; }
         public SubscriberConfig Config { get; set; }
         public List<Subscription> Subscriptions { get; set; }

--- a/BusinessLogic/Entities/Subscription.cs
+++ b/BusinessLogic/Entities/Subscription.cs
@@ -17,8 +17,9 @@ namespace EventManager.BusinessLogic.Entities
         public Subscriber Subscriber { get; set; }
         public HttpMethod Method { get; set; }
         public string EndPoint { get; set; }
-        public List<Action<Event>> CallBacks { get; set; }
+        public List<Func<Event, HttpResponseMessage>> CallBacks { get; set; }
         public bool IsExternal { get; set; }
+        public bool Synchronous { get; set; }
 
         public IAuthHandler Auth { get; set; }
 
@@ -99,7 +100,15 @@ namespace EventManager.BusinessLogic.Entities
                 {
                     foreach (var callback in CallBacks)
                     {
+                        // if the subscription is synchronous then it should only have one callback
+                        // so we're safe returning its response here
+                        if (this.Synchronous)
+                        {
+                            return callback.Invoke(_event);
+                        }
+
                         callback.Invoke(_event);
+
                         //TODO Handle async actions
                     }
                     string SerializedString = "true";

--- a/EventManager.csproj
+++ b/EventManager.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;</TargetFrameworks>
     <RootNamespace>EventManager</RootNamespace>
     <PackageId>Cecropia.Utilities.EventManager</PackageId>
-    <Version>1.2.0</Version>
+    <Version>2.0.0</Version>
     <Authors>Cecropia</Authors>
     <Company>Cecropia</Company>
     <!-- <GeneratePackageOnBuild>true</GeneratePackageOnBuild> -->

--- a/ExecutableTest/Program.cs
+++ b/ExecutableTest/Program.cs
@@ -56,9 +56,7 @@ namespace ExecutableTest
                 ExtraParams = json["ExtraParams"].ToObject<JObject>(),
             };
 
-            List<Action<Event>> callbacks = new List<Action<Event>>();
-
-            Subscriber subscriber = new Subscriber()
+            Subscriber subscriber = new Subscriber("Subscriber Name 1")
             {
                 Config = new SubscriberConfig
                 {
@@ -73,7 +71,7 @@ namespace ExecutableTest
                 EventName = "event_name",
                 Method = HttpMethod.Post,
                 EndPoint = EventManagerConstants.EventReceptionPath,
-                CallBacks = callbacks
+                CallBacks = new List<Func<Event, HttpResponseMessage>>()
             };
 
             QueueItem q1 = new QueueItem()
@@ -139,16 +137,17 @@ namespace ExecutableTest
                 .WriteTo.Console()
                 .CreateLogger();
 
-            List<Action<Event>> callbacks = new List<Action<Event>>();
+            List<Func<Event, HttpResponseMessage>> callbacks = new List<Func<Event, HttpResponseMessage>>();
 
-            Action<Event> callback = (Event e) => {
+            Func<Event, HttpResponseMessage> callback = (Event e) => {
                 Log.Debug("---- Call from Subscription callback");
+                return null;
             };
 
             callbacks.Add(callback);
 
 
-            Subscriber subscriber = new Subscriber()
+            Subscriber subscriber = new Subscriber("Subscriber Name 2")
             {
                 Config = new SubscriberConfig
                 {
@@ -164,15 +163,22 @@ namespace ExecutableTest
                 Method = HttpMethod.Post,
                 EndPoint = EventManagerConstants.EventReceptionPath,
                 CallBacks = callbacks,
-                IsExternal = false
+                IsExternal = false,
+                Synchronous = false
             };
+
 
             EventDispatcher.Register(subscription);
 
+            EventDispatcher.RegisterLocal("careers_salesforce_after_skill_created", OnEvent1, false);
+
             EventDispatcher.RegisterLocal("careers_salesforce_after_skill_created", (Event e) =>
             {
-                Log.Debug("---- Call from RegisterLocal callback");
-            });
+                Log.Debug("---- Call from RegisterLocal callback 2");
+                return null;
+            }, true);
+
+            
 
             //-----------------------------------------------//
 
@@ -187,7 +193,7 @@ namespace ExecutableTest
                     {'item2':'value2'}
                   ],
                   'Timestamp': '2020-05-22T21:28:06.496Z',
-                  'ExtraParams': { 'name': 'value'}, 
+                  'ExtraParams': { 'name': 'value'}
                 }
             ";
 
@@ -209,6 +215,12 @@ namespace ExecutableTest
 
 
             Console.ReadKey();
+        }
+
+        private static HttpResponseMessage OnEvent1(Event e)
+        {
+            Log.Debug("---- Call from RegisterLocal callback");
+            return null;
         }
 
     }


### PR DESCRIPTION
Resolves #27 

Restrict to only one Synchronous Register

Call Synchronous only if Payload has the boolean

- Synchronous also comes from the incomming payload.

Restoring to execute all async first then sync

- We execute first all the Async calls
- We execute last the Sync call to not interrupt the Async calls
- We return the Sync response payload to the EM endpoint back to the caller

Callback return response