### PR TITLE
Add metadata into Subscriptions

### DIFF
--- a/BusinessLogic/Entities/EventDispatcher.cs
+++ b/BusinessLogic/Entities/EventDispatcher.cs
@@ -148,8 +148,11 @@ namespace EventManager.BusinessLogic.Entities
         /// <param name="e">Event object</param>
         public HttpResponseMessage Dispatch(Event e, List<Subscription> subscriptions = null)
         {
+
+            subscriptions = subscriptions??new List<Subscription>();
+
             Log.Debug($"EventDispatcher.Dispatch: Dispatching event with name '{e.Name}'");
-            
+
             if(subscriptions == null && eventSubscriptions.ContainsKey(e.Name)){
                 subscriptions = eventSubscriptions[e.Name];
             }

--- a/BusinessLogic/Entities/EventDispatcher.cs
+++ b/BusinessLogic/Entities/EventDispatcher.cs
@@ -122,8 +122,11 @@ namespace EventManager.BusinessLogic.Entities
         /// of accepting a complete <see cref="Event"/>, it takes the event name and payload and proceeds to build
         /// an event out of these.
         ///
-        /// Optionally, also a dictionary of urlTemplateValues that will be used to replace the templateKeys in the
+        /// Optionally:
+        /// - urlTemplateValues dictionary that will be used to replace the templateKeys in the
         /// endpoint. By default this dictionary is null.
+        /// - subscriptions List<Subscription> that will be used to replace the local list of destinations used as
+        /// endpoint. By default the List is null.
         ///
         /// The event dispatched with this method will have a `Timestamp` of `DateTime.UtcNow`, and the `ExtraParams`
         /// will be `null. If you need to specify any of these then use the normal `Dispatch` method.
@@ -144,12 +147,17 @@ namespace EventManager.BusinessLogic.Entities
 
         /// <summary>
         /// Fire an Event to be listened by a Subscription
+        ///
+        /// Optionally:
+        /// - subscriptions List<Subscription> that will be used to replace the local list of destinations used as
+        /// endpoint. By default the List is null.
+        ///
         /// </summary>
         /// <param name="e">Event object</param>
         public HttpResponseMessage Dispatch(Event e, List<Subscription> subscriptions = null)
         {
             Log.Debug($"EventDispatcher.Dispatch: Dispatching event with name '{e.Name}'");
-            
+
             if(subscriptions == null && eventSubscriptions.ContainsKey(e.Name)){
                 subscriptions = eventSubscriptions[e.Name];
             }

--- a/BusinessLogic/Entities/Subscription.cs
+++ b/BusinessLogic/Entities/Subscription.cs
@@ -20,15 +20,15 @@ namespace EventManager.BusinessLogic.Entities
         public List<Func<Event, HttpResponseMessage>> CallBacks { get; set; }
         public bool IsExternal { get; set; }
         public bool Synchronous { get; set; }
-
         public IAuthHandler Auth { get; set; }
+        public Dictionary<string, object> Metadata = new Dictionary<string, object>();
 
         public Subscription()
         {
         }
 
         /// <summary>
-        /// This method can be used to replace the templateValues in the provided "str". Each template value in str 
+        /// This method can be used to replace the templateValues in the provided "str". Each template value in str
         /// should have the shape "{templateValueName}". This method will find all instances of said templateValues
         /// and look for "templateValueName" in the <paramref name="templateValues"/> dictionary. Note that if no templateValue
         /// is found for a key then this is an error and it will throw a <see cref="System.Collections.Generic.KeyNotFoundException"/>.

--- a/EventManager.csproj
+++ b/EventManager.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;</TargetFrameworks>
     <RootNamespace>EventManager</RootNamespace>
     <PackageId>Cecropia.Utilities.EventManager</PackageId>
-    <Version>3.0.1</Version>
+    <Version>3.0.2</Version>
     <Authors>Cecropia</Authors>
     <Company>Cecropia</Company>
     <!-- <GeneratePackageOnBuild>true</GeneratePackageOnBuild> -->


### PR DESCRIPTION
On some cases, it is necessary to have other configuration elements at the time of making a request, that is why in this version 3.0.2 a metadata object is added in the Subscriptions allowing it to be used to make special configurations such as authorization.