### PR TITLE
CP-1849 Avoid multiple authorize request when accessing the CRM

### DIFF
--- a/BusinessLogic/Constants.cs
+++ b/BusinessLogic/Constants.cs
@@ -1,0 +1,13 @@
+namespace EventManager.BusinessLogic
+{
+    /// <summary>
+    /// Class containing constant values used in different operations
+    /// </summary>
+    public sealed class Constants
+    {
+        /// <summary>
+        /// The access token key
+        /// </summary>
+        public const string AccessTokenKey = "AccessTokenKey";
+    }
+}

--- a/BusinessLogic/Entities/Auth/BasicAuth.cs
+++ b/BusinessLogic/Entities/Auth/BasicAuth.cs
@@ -26,7 +26,7 @@ namespace EventManager.BusinessLogic.Entities.Auth
             Username = authConfig.Username;
             Password = authConfig.Password;
         }
-        public async Task<HttpResponseMessage> SendEvent(Event e, Subscription subscription)
+        public async Task<HttpResponseMessage> SendEvent(Event e, Subscription subscription, List<KeyValuePair<string, string>> paramsList = null)
         {
             Log.Debug("BasicAuth.SendEvent");
 

--- a/BusinessLogic/Entities/Auth/CustomAuthAdapter.cs
+++ b/BusinessLogic/Entities/Auth/CustomAuthAdapter.cs
@@ -30,7 +30,7 @@ namespace EventManager.BusinessLogic.Entities.Auth
         {
             this.authConfig = authConfig;
         }
-        public async Task<HttpResponseMessage> SendEvent(Event e, Subscription subscription)
+        public async Task<HttpResponseMessage> SendEvent(Event e, Subscription subscription, List<KeyValuePair<string, string>> paramsList = null)
         {
             Log.Debug("CustomAuthAdapter.SendEvent");
 

--- a/BusinessLogic/Entities/Auth/NoneAuth.cs
+++ b/BusinessLogic/Entities/Auth/NoneAuth.cs
@@ -17,7 +17,7 @@ namespace EventManager.BusinessLogic.Entities.Auth
         {
             this.authConfig = authConfig;
         }
-        public async Task<HttpResponseMessage> SendEvent(Event e, Subscription s)
+        public async Task<HttpResponseMessage> SendEvent(Event e, Subscription s, List<KeyValuePair<string, string>> paramsList = null)
         {
             Log.Debug("NoneAuth.SendEvent");
 

--- a/BusinessLogic/Entities/Auth/OAuthClientPassword.cs
+++ b/BusinessLogic/Entities/Auth/OAuthClientPassword.cs
@@ -74,13 +74,13 @@ namespace EventManager.BusinessLogic.Entities.Auth
                                 { "password", Password }
                             }
                         );
-                        var response = await client.PostAsync(LoginEndpoint, encodedContent);
+                        HttpResponseMessage response = await client.PostAsync(LoginEndpoint, encodedContent);
                         jsonResponse = response.Content.ReadAsStringAsync().Result;
                     }
 
                     Log.Debug($"OAuthClientPassword.SendEvent, Credentials response: {jsonResponse}");
 
-                    var values = JsonConvert.DeserializeObject<Dictionary<string, string>>(jsonResponse);
+                    Dictionary<string, string> values = JsonConvert.DeserializeObject<Dictionary<string, string>>(jsonResponse);
                     if (values.ContainsKey("error"))
                     {
                         // fail if there was an error
@@ -99,7 +99,7 @@ namespace EventManager.BusinessLogic.Entities.Auth
             Log.Debug($"OAuthClientPassword.SendEvent, Using access_token: {AccessToken}");
 
             // build request
-            var request = new HttpRequestMessage(subscription.Method, subscription.EndPoint);
+            HttpRequestMessage request = new HttpRequestMessage(subscription.Method, subscription.EndPoint);
             request.Headers.Add("Authorization", "Bearer " + AccessToken);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(TypeJson));
             request.Content = new StringContent(e.Payload, Encoding.UTF8, TypeJson);
@@ -113,7 +113,7 @@ namespace EventManager.BusinessLogic.Entities.Auth
 
             Log.Debug($"OAuthClientPassword.SendEvent, StatusCode:  {httpResponseMessage.StatusCode}");
 
-            var responseResult = await httpResponseMessage.Content.ReadAsStringAsync();
+            string responseResult = await httpResponseMessage.Content.ReadAsStringAsync();
 
             // Check for errors: EM should trigger a retry if the response is invalid
             if (httpResponseMessage.StatusCode == System.Net.HttpStatusCode.BadRequest)

--- a/BusinessLogic/Entities/Auth/OAuthClientPassword.cs
+++ b/BusinessLogic/Entities/Auth/OAuthClientPassword.cs
@@ -39,54 +39,67 @@ namespace EventManager.BusinessLogic.Entities.Auth
             Username = authConfig.Username;
             Password = authConfig.Password;
         }
-        public async Task<HttpResponseMessage> SendEvent(Event e, Subscription subscription)
+        public async Task<HttpResponseMessage> SendEvent(Event e, Subscription subscription, List<KeyValuePair<string, string>> paramsList = null)
         {
             Log.Debug("OAuthClientPassword.SendEvent");
 
             HttpResponseMessage httpResponseMessage;
-            HttpResponseMessage response;
-            string jsonResponse;
 
             // obtain access token only if necessary
             if (AccessToken == null)
             {
-                Log.Debug($"OAuthClientPassword.SendEvent: Obtaining access token for {subscription.Subscriber.Name}");
-                using (var client = new HttpClient())
+                if (paramsList != null && paramsList.Any())
                 {
-                    var encodedContent = new FormUrlEncodedContent(new Dictionary<string, string>
-                        {
-                            {"grant_type", "password"},
-                            {"client_id", ClientId},
-                            {"client_secret", ClientSecret},
-                            {"username", Username},
-                            {"password", Password}
-                        }
-                    );
-                    response = await client.PostAsync(LoginEndpoint, encodedContent);
-                    jsonResponse = response.Content.ReadAsStringAsync().Result;
-                }
-
-                Log.Debug($"OAuthClientPassword.SendEvent, Credentials response: {jsonResponse}");
-
-                Dictionary<string, string> values = JsonConvert.DeserializeObject<Dictionary<string, string>>(jsonResponse);
-                if (values.ContainsKey("error"))
-                {
-                    // fail if there was an error
-                    httpResponseMessage = new HttpResponseMessage(HttpStatusCode.BadRequest)
+                    var accessToken = paramsList.FirstOrDefault(x =>
+                        x.Key.Equals(Constants.AccessTokenKey, StringComparison.InvariantCultureIgnoreCase)).Value;
+                    if (!string.IsNullOrEmpty(accessToken))
                     {
-                        Content = new StringContent("error", Encoding.UTF8, "application/json")
-                    };
-                    return httpResponseMessage;
+                        AccessToken = accessToken;
+                    }
                 }
+                else
+                {
 
-                // otherwise set access token property
-                AccessToken = values["access_token"];
+                    Log.Debug(
+                        $"OAuthClientPassword.SendEvent: Obtaining access token for {subscription.Subscriber.Name}");
+                    string jsonResponse;
+                    using (var client = new HttpClient())
+                    {
+                        var encodedContent = new FormUrlEncodedContent(new Dictionary<string, string>
+                            {
+                                { "grant_type", "password" },
+                                { "client_id", ClientId },
+                                { "client_secret", ClientSecret },
+                                { "username", Username },
+                                { "password", Password }
+                            }
+                        );
+                        var response = await client.PostAsync(LoginEndpoint, encodedContent);
+                        jsonResponse = response.Content.ReadAsStringAsync().Result;
+                    }
+
+                    Log.Debug($"OAuthClientPassword.SendEvent, Credentials response: {jsonResponse}");
+
+                    var values = JsonConvert.DeserializeObject<Dictionary<string, string>>(jsonResponse);
+                    if (values.ContainsKey("error"))
+                    {
+                        // fail if there was an error
+                        httpResponseMessage = new HttpResponseMessage(HttpStatusCode.BadRequest)
+                        {
+                            Content = new StringContent("error", Encoding.UTF8, "application/json")
+                        };
+                        return httpResponseMessage;
+                    }
+
+                    // otherwise set access token property
+                    AccessToken = values["access_token"];
+                }
             }
 
             Log.Debug($"OAuthClientPassword.SendEvent, Using access_token: {AccessToken}");
 
             // build request
-            HttpRequestMessage request = new HttpRequestMessage(subscription.Method, subscription.EndPoint);
+            var request = new HttpRequestMessage(subscription.Method, subscription.EndPoint);
             request.Headers.Add("Authorization", "Bearer " + AccessToken);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(TypeJson));
             request.Content = new StringContent(e.Payload, Encoding.UTF8, TypeJson);
@@ -100,7 +113,7 @@ namespace EventManager.BusinessLogic.Entities.Auth
 
             Log.Debug($"OAuthClientPassword.SendEvent, StatusCode:  {httpResponseMessage.StatusCode}");
 
-            string responseResult = await httpResponseMessage.Content.ReadAsStringAsync();
+            var responseResult = await httpResponseMessage.Content.ReadAsStringAsync();
 
             // Check for errors: EM should trigger a retry if the response is invalid
             if (httpResponseMessage.StatusCode == System.Net.HttpStatusCode.BadRequest)

--- a/BusinessLogic/Entities/EventDispatcher.cs
+++ b/BusinessLogic/Entities/EventDispatcher.cs
@@ -45,10 +45,10 @@ namespace EventManager.BusinessLogic.Entities
             // If there is already a synchronous subscription then raise an exception
             if (subscription.Synchronous)
             {
-                var syncSubscription = GetSynchronousSubscription(subscription.EventName);
+                Subscription syncSubscription = GetSynchronousSubscription(subscription.EventName);
                 if (syncSubscription != null)
                 {
-                    var check =
+                    string check =
                         // check appsettings
                         syncSubscription.IsExternal ? "appsettings.json 'EventManager' block" :
                         // check  RegisterLocal methods
@@ -80,12 +80,12 @@ namespace EventManager.BusinessLogic.Entities
         /// <param name="synchronous"></param>
         public void RegisterLocal(string eventName, Func<Event, HttpResponseMessage> callback, bool synchronous = false)
         {
-            var callbacks = new List<Func<Event, HttpResponseMessage>>
+            List<Func<Event, HttpResponseMessage>> callbacks = new List<Func<Event, HttpResponseMessage>>
             {
                 callback
             };
 
-            var subscriber = new Subscriber(callback.Method.Name)
+            Subscriber subscriber = new Subscriber(callback.Method.Name)
             {
                 Config = new SubscriberConfig
                 {
@@ -95,7 +95,7 @@ namespace EventManager.BusinessLogic.Entities
             };
 
 
-            var subscription = new Subscription()
+            Subscription subscription = new Subscription()
             {
                 Subscriber = subscriber,
                 EventName = eventName,
@@ -166,10 +166,10 @@ namespace EventManager.BusinessLogic.Entities
 
             subscriptions = subscriptions ?? new List<Subscription>();
 
-            foreach (var subscription in subscriptions.Where(x => !x.Synchronous))
+            foreach (Subscription subscription in subscriptions.Where(x => !x.Synchronous))
             {
                 Log.Debug($"EventDispatcher.Dispatch: Enqueuing item for subscriber '{subscription.Subscriber.Name}', for event '{e.Name}'");
-                var queueItem = new QueueItem()
+                QueueItem queueItem = new QueueItem()
                 {
                     Guid = Guid.NewGuid(),
                     Event = e,
@@ -181,7 +181,7 @@ namespace EventManager.BusinessLogic.Entities
                 queue.Add(queueItem);
             }
             // move to last because the return will break the other Queue items
-            var synchronousSubscription = subscriptions.FirstOrDefault(s => s.Synchronous);
+            Subscription synchronousSubscription = subscriptions.FirstOrDefault(s => s.Synchronous);
 
             // if there is no synchronous event then just return an empty response with 200 status code
             if (synchronousSubscription == null) return new HttpResponseMessage(System.Net.HttpStatusCode.OK);

--- a/BusinessLogic/Entities/EventDispatcher.cs
+++ b/BusinessLogic/Entities/EventDispatcher.cs
@@ -10,7 +10,7 @@ namespace EventManager.BusinessLogic.Entities
     public sealed class EventDispatcher
     {
         private static readonly Lazy<EventDispatcher> lazy = new Lazy<EventDispatcher>(() => new EventDispatcher());
-        public static EventDispatcher Instance => lazy.Value;
+        public static EventDispatcher Instance { get { return lazy.Value; } }
 
         private static Queue queue;
 

--- a/BusinessLogic/Entities/EventDispatcher.cs
+++ b/BusinessLogic/Entities/EventDispatcher.cs
@@ -10,7 +10,7 @@ namespace EventManager.BusinessLogic.Entities
     public sealed class EventDispatcher
     {
         private static readonly Lazy<EventDispatcher> lazy = new Lazy<EventDispatcher>(() => new EventDispatcher());
-        public static EventDispatcher Instance { get { return lazy.Value; } }
+        public static EventDispatcher Instance => lazy.Value;
 
         private static Queue queue;
 
@@ -18,7 +18,6 @@ namespace EventManager.BusinessLogic.Entities
 
         // Dictionary is Thread safe.
         private static Dictionary<string, List<Subscription>> eventSubscriptions;
-
 
         /// <summary>
         /// EventDispatcher Constructor, only invoked through Instance
@@ -46,27 +45,20 @@ namespace EventManager.BusinessLogic.Entities
             // If there is already a synchronous subscription then raise an exception
             if (subscription.Synchronous)
             {
-                Subscription syncSubscription = GetSynchronousSubscription(subscription.EventName);
+                var syncSubscription = GetSynchronousSubscription(subscription.EventName);
                 if (syncSubscription != null)
                 {
-                    string check;
-                    if (syncSubscription.IsExternal)
-                    {
+                    var check =
                         // check appsettings
-                        check = "appsettings.json 'EventManager' block";
-                    }
-                    else
-                    {
+                        syncSubscription.IsExternal ? "appsettings.json 'EventManager' block" :
                         // check  RegisterLocal methods
-                        check = "your 'EventDispatcher.RegisterLocal' calls";
-                    }
+                        "your 'EventDispatcher.RegisterLocal' calls";
 
                     throw new ArgumentException($"EventDispatcher.Register: '{syncSubscription.Subscriber.Name}' already exists for '{syncSubscription.EventName}'.\nOnly one Synchronous Subscription is allowed. \nCheck {check}, for 'Synchronous: true'.");
                 }
             }
 
-            List<Subscription> subscriptions;
-            if (eventSubscriptions.TryGetValue(subscription.EventName, out subscriptions))
+            if (eventSubscriptions.TryGetValue(subscription.EventName, out var subscriptions))
             {
                 subscriptions.Add(subscription);
             }
@@ -81,18 +73,19 @@ namespace EventManager.BusinessLogic.Entities
         }
 
         /// <summary>
-        /// Allows to assing a function to be executed when an Event is called.
+        /// Allows to assign a function to be executed when an Event is called.
         /// </summary>
         /// <param name="eventName">Name of the event to attach the callback.</param>
         /// <param name="callback">Lambda that will be executed when the event is fired,</param>
+        /// <param name="synchronous"></param>
         public void RegisterLocal(string eventName, Func<Event, HttpResponseMessage> callback, bool synchronous = false)
         {
-            List<Func<Event, HttpResponseMessage>> callbacks = new List<Func<Event, HttpResponseMessage>>
+            var callbacks = new List<Func<Event, HttpResponseMessage>>
             {
                 callback
             };
 
-            Subscriber subscriber = new Subscriber(callback.Method.Name)
+            var subscriber = new Subscriber(callback.Method.Name)
             {
                 Config = new SubscriberConfig
                 {
@@ -102,7 +95,7 @@ namespace EventManager.BusinessLogic.Entities
             };
 
 
-            Subscription subscription = new Subscription()
+            var subscription = new Subscription()
             {
                 Subscriber = subscriber,
                 EventName = eventName,
@@ -118,14 +111,14 @@ namespace EventManager.BusinessLogic.Entities
         }
 
         /// <summary>
-        /// This is a simplified version of the <see cref="EventDispatcher.Dispatch(Event)"/> method. But instead
+        /// This is a simplified version of the <see cref="EventDispatcher.Dispatch(Event,List{EventManager.BusinessLogic.Entities.Subscription})"/> method. But instead
         /// of accepting a complete <see cref="Event"/>, it takes the event name and payload and proceeds to build
         /// an event out of these.
         ///
         /// Optionally:
         /// - urlTemplateValues dictionary that will be used to replace the templateKeys in the
         /// endpoint. By default this dictionary is null.
-        /// - subscriptions List<Subscription> that will be used to replace the local list of destinations used as
+        /// - subscriptions <see cref="List{Subscription}"/> that will be used to replace the local list of destinations used as
         /// endpoint. By default the List is null.
         ///
         /// The event dispatched with this method will have a `Timestamp` of `DateTime.UtcNow`, and the `ExtraParams`
@@ -133,7 +126,12 @@ namespace EventManager.BusinessLogic.Entities
         /// </summary>
         /// <param name="eventName"></param>
         /// <param name="eventPayload"></param>
-        public void SimpleDispatch(string eventName, string eventPayload, Dictionary<string, string> urlTemplateValues = null,List<Subscription> subscriptions = null)
+        /// <param name="urlTemplateValues">dictionary that will be used to replace the templateKeys in the
+        ///     endpoint. By default this dictionary is null.</param>
+        /// <param name="subscriptions"><see cref="List{Subscription}"/> that will be used to replace the local list of destinations used as
+        ///     endpoint. By default the List is null.</param>
+        /// <param name="paramsList">takes a list of key value pairs used for further configure the behavior of the dispatch logic</param>
+        public void SimpleDispatch(string eventName, string eventPayload, Dictionary<string, string> urlTemplateValues = null,List<Subscription> subscriptions = null, List<KeyValuePair<string, string>> paramsList = null)
         {
             this.Dispatch(new Event
             {
@@ -142,54 +140,53 @@ namespace EventManager.BusinessLogic.Entities
                 Timestamp = DateTime.UtcNow,
                 ExtraParams = null,
                 UrlTemplateValues = urlTemplateValues
-            }, subscriptions );
+            }, subscriptions, paramsList);
         }
 
         /// <summary>
         /// Fire an Event to be listened by a Subscription
         ///
         /// Optionally:
-        /// - subscriptions List<Subscription> that will be used to replace the local list of destinations used as
+        /// - subscriptions <see cref="List{Subscription}"/> that will be used to replace the local list of destinations used as
         /// endpoint. By default the List is null.
         ///
         /// </summary>
         /// <param name="e">Event object</param>
-        public HttpResponseMessage Dispatch(Event e, List<Subscription> subscriptions = null)
+        /// <param name="subscriptions"><see cref="List{Subscription}"/> that will be used to replace the local list of destinations used as
+        /// endpoint. By default the List is null.</param>
+        /// <param name="paramsList">takes a list of key value pairs used for further configure the behavior of the dispatch logic</param>
+        public HttpResponseMessage Dispatch(Event e, List<Subscription> subscriptions = null, List<KeyValuePair<string,string>> paramsList = null)
         {
 
             Log.Debug($"EventDispatcher.Dispatch: Dispatching event with name '{e.Name}'");
 
-            if(subscriptions == null && eventSubscriptions.ContainsKey(e.Name)){
-                subscriptions = eventSubscriptions[e.Name];
+            if(subscriptions == null && eventSubscriptions.TryGetValue(e.Name, out var eventSubscription)){
+                subscriptions = eventSubscription;
             }
 
             subscriptions = subscriptions ?? new List<Subscription>();
 
-            foreach (Subscription subscription in subscriptions.Where(x => !x.Synchronous))
+            foreach (var subscription in subscriptions.Where(x => !x.Synchronous))
             {
                 Log.Debug($"EventDispatcher.Dispatch: Enqueuing item for subscriber '{subscription.Subscriber.Name}', for event '{e.Name}'");
-                QueueItem queueItem = new QueueItem()
+                var queueItem = new QueueItem()
                 {
                     Guid = Guid.NewGuid(),
                     Event = e,
                     Subscription = subscription,
-                    Timestamp = DateTime.Now
+                    Timestamp = DateTime.Now,
+                    ParamsList = paramsList
                 };
 
                 queue.Add(queueItem);
             }
             // move to last because the return will break the other Queue items
-            Subscription synchronousSubscription = subscriptions.FirstOrDefault(s => s.Synchronous);
+            var synchronousSubscription = subscriptions.FirstOrDefault(s => s.Synchronous);
 
-            if (synchronousSubscription != null)
-            {
-                Log.Debug($"EventDispatcher.Dispatch: Executing Synchronous call for Event: '{e.Name}'");
-                return synchronousSubscription.SendEvent(e).Result;
-            }
             // if there is no synchronous event then just return an empty response with 200 status code
-
-            return new HttpResponseMessage(System.Net.HttpStatusCode.OK);
-
+            if (synchronousSubscription == null) return new HttpResponseMessage(System.Net.HttpStatusCode.OK);
+            Log.Debug($"EventDispatcher.Dispatch: Executing Synchronous call for Event: '{e.Name}'");
+            return synchronousSubscription.SendEvent(e, paramsList).Result;
         }
 
         /// <summary>
@@ -200,8 +197,7 @@ namespace EventManager.BusinessLogic.Entities
         public Subscription GetSynchronousSubscription(string eventName)
         {
             Subscription syncSubscription = null;
-            List<Subscription> subscriptions;
-            eventSubscriptions.TryGetValue(eventName, out subscriptions);
+            eventSubscriptions.TryGetValue(eventName, out var subscriptions);
             if (subscriptions != null)
             {
                 syncSubscription = subscriptions.FirstOrDefault(s => s.Synchronous == true);

--- a/BusinessLogic/Entities/Queue.cs
+++ b/BusinessLogic/Entities/Queue.cs
@@ -106,7 +106,7 @@ namespace EventManager.BusinessLogic.Entities
                 if (++item.Tries <= subscriberConfig.MaxTries)
                 {
                     item.LastTry = DateTime.Now;
-                    HttpResponseMessage httpResponseMessage = await item.Subscription.SendEvent(item.Event);
+                    HttpResponseMessage httpResponseMessage = await item.Subscription.SendEvent(item.Event, item.ParamsList);
 
                     if (httpResponseMessage.IsSuccessStatusCode)
                     {
@@ -118,8 +118,7 @@ namespace EventManager.BusinessLogic.Entities
 
                         EventDispatcher.Instance.SimpleDispatch(
                             eventName: EventManagerConstants.ReplyEventPrefix + item.Event.Name,
-                            eventPayload: contents
-                        );
+                            eventPayload: contents, paramsList: item.ParamsList);
 
                         /////////////////////////////////
 

--- a/BusinessLogic/Entities/QueueItem.cs
+++ b/BusinessLogic/Entities/QueueItem.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Threading;
 
@@ -13,5 +14,6 @@ namespace EventManager.BusinessLogic.Entities
         public DateTime Timestamp { get; set; }
         public DateTime LastTry { get; set; }
         public int Tries { get; set; }
+        public List<KeyValuePair<string, string>> ParamsList { get; set; } = new List<KeyValuePair<string, string>>();
     }
 }

--- a/BusinessLogic/Factories/AuthFactory.cs
+++ b/BusinessLogic/Factories/AuthFactory.cs
@@ -11,7 +11,7 @@ namespace EventManager.BusinessLogic.Factories
     public class AuthFactory
     {
         /// <summary>
-        /// Retrieves the appropiate Authorization
+        /// Retrieves the appropriate Authorization
         /// </summary>
         /// <param name="auth">Object representing the EventManager.Auth section inside AppSettings.json</param>
         /// <returns>Authorization as an IAuthHandler</returns>

--- a/BusinessLogic/Interfaces/IAuthHandler.cs
+++ b/BusinessLogic/Interfaces/IAuthHandler.cs
@@ -5,6 +5,8 @@ using System.Threading.Tasks;
 
 namespace EventManager.BusinessLogic.Interfaces
 {
+    using System.Collections.Generic;
+
     /// <summary>
     /// Every AuthHandler implements a different authentication mechanism, and is an abstraction layer
     /// that is in charge of sending Events to Subscribers respecting the Subscriber configuration.
@@ -17,8 +19,9 @@ namespace EventManager.BusinessLogic.Interfaces
         /// </summary>
         /// <param name="e">The Event we want to send</param>
         /// <param name="s">The Subscription that specifies how the event is to be sent</param>
+        /// <param name="paramsList">Takes a list of key value pairs used for further configure the behavior of the send event logic</param>
         /// <returns>The response message obtained after sending the event</returns>
-        Task<HttpResponseMessage> SendEvent(Event e, Subscription s);
+        Task<HttpResponseMessage> SendEvent(Event e, Subscription s, List<KeyValuePair<string, string>> paramsList = null);
 
         /// <summary>
         /// This method is used to validate the configuration provided for this Subscriber. The idea

--- a/EventManager.csproj
+++ b/EventManager.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;</TargetFrameworks>
     <RootNamespace>EventManager</RootNamespace>
     <PackageId>Cecropia.Utilities.EventManager</PackageId>
-    <Version>3.0.4</Version>
+    <Version>3.0.5</Version>
     <Authors>Cecropia</Authors>
     <Company>Cecropia</Company>
     <!-- <GeneratePackageOnBuild>true</GeneratePackageOnBuild> -->

--- a/ExecutableTest/ExecutableTest.csproj
+++ b/ExecutableTest/ExecutableTest.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
https://cecropia.atlassian.net/browse/CP-1849

Adding logic changes to allow to pass a list of parameters which clients  consuming the dll can use to pass in handy parameters to the dispatch and send message logic, for instance it can be used to pass in the access token to avoid making multiple calls if the consuming app already has it
